### PR TITLE
Updating config operation, adding .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+__pycache__
+config.ini

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Coded to support Python3
 
 - Define settings in config.ini
 
-The BackpackingMapper utilizes the trail database affiliated with [HikingProject](http://hikingproject.com).  You will need to establish an account with hiking project, and find your [private developer API key](https://www.hikingproject.com/data).  For the program to work, the following HikingProject account information must be stored in the config.ini file:
+The BackpackingMapper utilizes the trail database affiliated with [HikingProject](http://hikingproject.com).  You will need to establish an account with hiking project, and find your [private developer API key](https://www.hikingproject.com/data).  For the program to work, the following HikingProject account information must be stored in a file named `config.ini`:
 
 - account email address
 - api_key
 - account password
+
+A sample `config.sample.ini` has been created - copy it or create a new `config.ini` for your own config.
 
 ## Planning a Trip
 

--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,0 @@
-[HikingProject.com]
-email = 
-api_key =
-password =

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,0 +1,4 @@
+[HikingProject.com]
+email = 
+api_key = 
+password = 


### PR DESCRIPTION
Welcoming feedback on this method for the config file. My concern here is that users may forget to clean out the `config.ini` file of their own repo and mistakenly upload their account credentials during PR creation. Instead I have the repo contain a `config.sample.ini` which simply needs to be copied to a `config.ini` which GitHub will _not_ track.

Also ignoring some of python's compiling/caching stuff here to avoid that noise when committing changes.